### PR TITLE
invalid form styling for BidPanel

### DIFF
--- a/src/components/App.scss
+++ b/src/components/App.scss
@@ -10,6 +10,7 @@
   --inactive-border: #4D5474;
   --inactive-header-text: rgba(255, 255, 255, 0.6);
   --inactive-text: rgba(255, 255, 255, 0.4);
+  --invalid-red: #DE6067;
   --logo-background: #191F32;
   --pending-panel-gray: #9094A0;
   --white-text: #FFFFFF;
@@ -41,4 +42,12 @@ input:focus {
 
 .popup-content {
   color: var(--background);
+}
+
+.invalid-border {
+  border-bottom: 1px solid var(--invalid-red);
+}
+
+.valid-border {
+  border-bottom: 1px solid var(--inactive-border);
 }

--- a/src/components/common/panels/BidPanel.js
+++ b/src/components/common/panels/BidPanel.js
@@ -25,7 +25,6 @@ const BidForm = styled.div`
   justify-content: space-between;
   margin-top: 18px;
   padding: 0px 20px 6px 20px;
-  border-bottom: 1px solid var(--inactive-border);
   input {
     font-size: 15px;
     line-height: 18px;
@@ -48,6 +47,17 @@ const PanelText = styled.div`
   padding: 24px 0px;
   margin-bottom: 32px;
   border-bottom: 1px solid var(--faint-divider);
+`
+
+const ValidationError = styled.div`
+  text-align: right;
+  color: var(--invalid-red);
+  font-family: Montserrat;
+  font-weight: 600;
+  font-size: 12px;
+  line-height: 15px;
+  margin-top: 8px;
+  margin-bottom: -23px;
 `
 
 @inject('root')
@@ -93,11 +103,12 @@ class BidPanel extends React.Component {
             GEN is the native DAOstack token, primarily used for prediction markets and boosting proposals.
           </PanelText>
           <div>Bid Amount</div>
-          <BidForm>
+          <BidForm className="invalid-border">
             <input type="text" name="name" placeholder="0" value={bidAmount} onChange={e => this.setBidAmount(e.target.value)} />
             <MaxTokensText onClick={e => this.setBidAmount(userBalance)}>Max</MaxTokensText>
             <div>GEN</div>
           </BidForm>
+          <ValidationError>Insufficient Balance</ValidationError>
         </BidWrapper>
         {actionEnabled ?
           (<ActiveButton


### PR DESCRIPTION

<img width="439" alt="Screen Shot 2019-10-28 at 2 55 09 PM" src="https://user-images.githubusercontent.com/874683/67708696-f4da4f00-f992-11e9-97ce-99515ed79224.png">


This adds styling for an invalid form input for the `BidPanel`  It still needs to be wired up.

To wire it up, the additions here can be used by toggling the class of the `BidForm` between `valid-border` and `invalid-border` and by adding or removing the `ValidationError` element with the appropriate error message.